### PR TITLE
Implemented size modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ You can hover over individual blocks in the flame graph to get more detailed inf
 
 You can pan the picture via drag and drop, and zoom via your mouse wheel.
 
+You can adjust the size of the picture by passing `width` and `height` arguments
+
+```julia
+@profview f(args...) width = 800 height = 600
+
+# or alternatively
+Profile.clear()
+@profile f(args...)
+ProfileVega.view(width = 800, height = 600)
+```
+
+Size parameters can also be set globally
+
+```julia
+ProfileView.set_default_size(800, 600)
+```
+
 ### Exporting figures
 
 Even if you don't use Jupyter, you might want to export a flame graph as

--- a/src/ProfileVega.jl
+++ b/src/ProfileVega.jl
@@ -5,6 +5,18 @@ using VegaLite: save
 
 export @profview, save
 
+mutable struct Options
+    width::Int
+    height::Int
+end
+
+global _options = Options(800, 400)
+
+function set_default_size(width, height)
+    _options.width = width
+    _options.height = height
+end
+
 function _add_node_to_data!(data, node, indent)
     push!(data, (level=indent, status=node.data.status==0 ? "Default" : node.data.status==1 ? "Runtime dispatch" : "Garbage collection", x1=node.data.span.start, x2=node.data.span.stop+.9, sf=string(node.data.sf)))
     for child in node
@@ -12,7 +24,7 @@ function _add_node_to_data!(data, node, indent)
     end
 end
 
-function _plotflamegraph(node)
+function _plotflamegraph(node; kwargs...)
     data = Vector{NamedTuple{(:level, :status, :x1, :x2, :sf), Tuple{Int,String,Float64,Float64,String}}}(undef, 0)
     _add_node_to_data!(data, node, 0)
 
@@ -36,8 +48,8 @@ function _plotflamegraph(node)
             {selection=:select, value=0.5}
             ],
             value=0},
-        width=800,
-        height=400,
+        width=get(kwargs, :width, _options.width),
+        height=get(kwargs, :height, _options.height),
         color={"status:n", legend={title=nothing, orient=:bottom}},
         tooltip=:sf,
         title="Profile Results"
@@ -51,9 +63,9 @@ View profiling results. See [FlameGraphs](https://github.com/timholy/FlameGraphs
 for options for `kwargs`.
 """
 function view(data::Vector{UInt64}=Profile.fetch(); kwargs...)
-    g = FlameGraphs.flamegraph(data; kwargs...)
+    g = FlameGraphs.flamegraph(data; filter(x -> !(x[1] in fieldnames(Options)), kwargs)...)
 
-    return _plotflamegraph(g)
+    return _plotflamegraph(g; kwargs...)
 end
 
 """
@@ -61,11 +73,11 @@ end
 
 Clear the Profile buffer, profile `f(args...)`, and view the result graphically.
 """
-macro profview(ex)
+macro profview(ex, args...)
     return quote
         Profile.clear()
         Profile.@profile $(esc(ex))
-        view()
+        view(;$(esc.(args)...))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ProfileVega
 import VegaLite
 using Test
+using Profile
 
 function profile_test(n)
     for i = 1:n
@@ -16,8 +17,37 @@ end
 
 @testset "ProfileVega" begin
 
-p1 = @profview profile_test(2)
+    p1 = @profview profile_test(2)
 
-@test p1 isa VegaLite.VLSpec
+    @test p1 isa VegaLite.VLSpec
+    @test p1.width == 800
+    @test p1.height == 400
 
+    ProfileVega.set_default_size(100, 200)
+    p2 = @profview profile_test(2)
+
+    @test p2.width == 100
+    @test p2.height == 200
+
+    p3 = @profview profile_test(2) width = 500
+    @test p3.width == 500
+    @test p3.height == 200
+
+    p4 = @profview profile_test(2) height = 600
+    @test p4.width == 100
+    @test p4.height == 600
+
+    p5 = @profview profile_test(2) height = 600 width = 400
+    @test p5.width == 400
+    @test p5.height == 600
+
+    Profile.clear()
+    @profile profile_test(10)
+    p6 = ProfileVega.view()
+    @test p6.width == 100
+    @test p6.height == 200
+
+    p7 = ProfileVega.view(width = 400, height = 500)
+    @test p7.width == 400
+    @test p7.height == 500
 end


### PR DESCRIPTION
As discussed in #4, added options to setup sizes globally and adjust them locally in `view` and `@profview` functions. As a side effect, it is possible now to pass `FlameGraph` arguments to `@profview` macros.

I am not sure in this implementation, cause usually I am trying to avoid global variables. Hope `global` keyword is enough to solve all possible problems.